### PR TITLE
Fix typo Update README.md

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/README.md
+++ b/packages/contracts-bedrock/test/kontrol/README.md
@@ -184,7 +184,7 @@ This project uses two different [`foundry.toml` profiles](../../foundry.toml), `
 - `kdeploy`: Used by [`make-summary-deployment.sh`](./scripts/make-summary-deployment.sh) to generate the [`DeploymentSummary.sol`](./proofs/utils/DeploymentSummary.sol) contract based on execution of the [`KontrolDeployment.sol`](./deployment/KontrolDeployment.sol) contract using Foundry's state diff recording cheatcodes.
   This is where all necessary [`src/L1`](../../src/L1) files are compiled with their bytecode saved into the [`DeploymentSummaryCode.sol`](./proofs/utils/DeploymentSummaryCode.sol) file, which is inherited by `DeploymentSummary`.
 
-- `kprove`: Used by the [`run-kontrol.sh`](./scrpts/run-kontrol.sh) script to execute proofs, which can be run once a `DeploymentSummary.sol` contract is present. This profile's `src` and `script` paths point to a test folder because we only want to compile what is in the `test/kontrol/proofs` folder, since that folder contains all bytecode and proofs.
+- `kprove`: Used by the [`run-kontrol.sh`](./scripts/run-kontrol.sh) script to execute proofs, which can be run once a `DeploymentSummary.sol` contract is present. This profile's `src` and `script` paths point to a test folder because we only want to compile what is in the `test/kontrol/proofs` folder, since that folder contains all bytecode and proofs.
 
 The `make-summary-deployment.sh` scripts saves off the generated JSON state diff to `snapshots/state-diff/Kontrol-Deploy.json`, and is run as part of the `snapshots` script in `package.json`.
 Therefore, the snapshots CI check will fail if the committed Kontrol state diff is out of sync.


### PR DESCRIPTION
# Fix Typo in README.md

## Description:

This pull request addresses a minor typographical error in the `README.md` file within the `contracts-bedrock/test/kontrol` directory. The fix corrects the file path from `./scrpts/run-kontrol.sh` to `./scripts/run-kontrol.sh`, ensuring accuracy and usability of the documentation.

## Changes:
- Corrected a typo: `./scrpts/run-kontrol.sh` → `./scripts/run-kontrol.sh` in `README.md`.

## File(s) Modified:
- `packages/contracts-bedrock/test/kontrol/README.md`

## Reasoning:

Precise documentation ensures developers can execute scripts and navigate project resources effectively. Fixing this typo eliminates potential confusion and enhances the overall quality of the documentation.

## Checklist:
- [x] Typographical error corrected.
- [x] Changes reviewed for adherence to contribution guidelines.
- [x] Documentation updated without affecting functionality.

## Related Issues:
- N/A

## Additional Notes:
This is a minor, documentation-only update and does not impact any functionality or project logic.
